### PR TITLE
For dependencies, use a default file target if the target is not registered

### DIFF
--- a/src/abstracttarget.jl
+++ b/src/abstracttarget.jl
@@ -99,7 +99,7 @@ funhash(f::Function, x) = hash(funhash(f), hash(convert(Vector{UTF8String}, x)))
 
 Return the dependencies of a target.
 """
-dependencies(t::AbstractTarget) = [resolve(d) for d in t.dependencies]
+dependencies(t::AbstractTarget) = [resolvedependency(d) for d in t.dependencies]
 
 function has1arg{T<:AbstractTarget}(t::T) 
     if isgeneric(t.action)

--- a/src/file.jl
+++ b/src/file.jl
@@ -20,6 +20,24 @@ type FileTarget <: AbstractTarget
     isstale::Bool
 end
 
+"""
+```julia
+resolvedependency(s::AbstractString)
+```
+
+Return the target registered under name `s`.
+"""
+function resolvedependency(s::AbstractString)
+    if haskey(tasks(), utf8(s))
+        tasks()[utf8(s)]
+    elseif isfile(s)
+        FileTarget(s, UTF8String[], "", () -> nothing,
+                   Dates.unix2datetime(mtime(s)), 0, false)
+    else
+        error("no rule for target '$s'")
+    end
+end
+
 function isstale(t::FileTarget)
     if !isfile(t.name) || t.isstale  
         return true 

--- a/src/file.jl
+++ b/src/file.jl
@@ -25,7 +25,8 @@ end
 resolvedependency(s::AbstractString)
 ```
 
-Return the target registered under name `s`.
+Return the target registered under name `s`. If no target is registered and a
+file of name `s` exists, return a new `FileTarget` for that file.
 """
 function resolvedependency(s::AbstractString)
     if haskey(tasks(), utf8(s))

--- a/test/example.jl
+++ b/test/example.jl
@@ -5,12 +5,6 @@ using Base.Test
 writecsv("in1.csv", rand(3,3))
 writecsv("in2.csv", rand(3,3))
 
-@desc "Input file 1"
-Maker.file("in1.csv")
-
-@desc "Input file 1"
-Maker.file("in2.csv")
-
 @desc "Combine input files"
 Maker.file("x.csv", ["in1.csv", "in2.csv"]) do 
     println("Reading input data.")
@@ -91,7 +85,7 @@ make()  # This should change `x` back to what it was.
 
 make("clean")
 
-@test length(tasks()) == 9
+@test length(tasks()) == 7
 @test tasks("clean").name == "clean"
 show(tasks())
 show(tasks("x.csv"))


### PR DESCRIPTION
This should address #20. It was a pretty easy change. I'm still a little queasy about it, but this is how it works in a Makefile or Rakefile.
